### PR TITLE
Install Cucumber from its Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,12 +59,11 @@ end
 
 group :test do
 	gem 'gherkin3', '>= 3.1.0'
-	gem 'cucumber', :git => "git://github.com/cucumber/cucumber-ruby.git", branch: "integrate-gherkin3-parser"
-	gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git", branch: "integrate-gherkin3-parser"
-	gem 'cucumber-rails', :git => "git://github.com/cucumber/cucumber-rails.git", require: false
+	gem 'cucumber', '>= 2.1.0'
+	gem 'cucumber-rails'
 
 	#gem 'capybara'
-    gem 'poltergeist'
+	gem 'poltergeist'
 	gem 'guard-rspec'
 	gem 'factory_girl_rails'
 	gem 'coveralls', require: false
@@ -72,7 +71,6 @@ group :test do
 	gem 'selenium-webdriver'
 	gem 'simplecov', require: false
 	gem 'webmock', require: false
-	#gem 'cucumber-rails', :require => false
 	gem 'database_cleaner'
 	gem 'mocha'
 end


### PR DESCRIPTION
The Gemfile was referencing a branch which has since been merged, and deleted from the Cucumber git repo. 

As per [this PR](https://github.com/cucumber/cucumber-ruby/pull/884) it's part of 2.1 and newer.